### PR TITLE
Abstracted out the stream coordination from the SequentialTagIndexer

### DIFF
--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/commons/service/persistence/SequentialTagIndexer.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/commons/service/persistence/SequentialTagIndexer.scala
@@ -1,134 +1,100 @@
 package ch.epfl.bluebrain.nexus.commons.service.persistence
 
-import akka.Done
-import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props}
-import akka.cluster.singleton.{ClusterSingletonManager, ClusterSingletonManagerSettings}
-import akka.pattern.pipe
+import akka.NotUsed
+import akka.actor.{ActorRef, ActorSystem}
+import akka.event.Logging
 import akka.persistence.query.scaladsl.EventsByTagQuery
 import akka.persistence.query.{EventEnvelope, Offset, PersistenceQuery}
-import akka.stream.scaladsl.{Keep, RunnableGraph, Sink}
-import akka.stream.{ActorMaterializer, KillSwitches, UniqueKillSwitch}
-import ch.epfl.bluebrain.nexus.commons.service.persistence.SequentialIndexer.Stop
+import akka.stream.scaladsl.Source
+import ch.epfl.bluebrain.nexus.commons.service.stream.SingletonStreamCoordinator
 import shapeless.Typeable
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 /**
   * Generic tag indexer that uses the specified resumable projection to iterate over the collection of events selected
-  * via the specified tag and apply the argument indexing function.  It should be started as a singleton actor in a
+  * via the specified tag and apply the argument indexing function.  It starts as a singleton actor in a
   * clustered deployment.  If the event type is not compatible with the events deserialized from the persistence store
   * the events are skipped.
-  *
-  * @param init         an initialization function that is run before the indexer is (re)started
-  * @param index        the indexing function
-  * @param projectionId the id of the resumable projection to use
-  * @param pluginId     the persistence query plugin id
-  * @param tag          the tag to use while selecting the events from the store
-  * @param T            a Typeable instance for the event type T
-  * @tparam T the event type
   */
-class SequentialTagIndexer[T](init: () => Future[Unit],
-                              index: T => Future[Unit],
-                              projectionId: String,
-                              pluginId: String,
-                              tag: String)(implicit T: Typeable[T])
-    extends Actor
-    with ActorLogging {
+object SequentialTagIndexer {
 
-  private implicit val as: ActorSystem       = context.system
-  private implicit val ec: ExecutionContext  = context.dispatcher
-  private implicit val mt: ActorMaterializer = ActorMaterializer()
-
-  private val projection = ResumableProjection(projectionId)
-  private val query      = PersistenceQuery(context.system).readJournalFor[EventsByTagQuery](pluginId)
-
-  private def initialize(): Unit = {
-    val _ = init().flatMap(_ => projection.fetchLatestOffset) pipeTo self
+  private[persistence] def initialize(underlying: () => Future[Unit], projectionId: String)(
+      implicit as: ActorSystem): () => Future[Offset] = {
+    import as.dispatcher
+    val projection = ResumableProjection(projectionId)
+    () =>
+      underlying().flatMap(_ => projection.fetchLatestOffset)
   }
 
-  override def preStart(): Unit = {
-    super.preStart()
-    initialize()
+  private[persistence] def source[T](index: T => Future[Unit], projectionId: String, pluginId: String, tag: String)(
+      implicit as: ActorSystem,
+      T: Typeable[T]): Offset => Source[Unit, NotUsed] = {
+    import as.dispatcher
+    val log        = Logging(as, SequentialTagIndexer.getClass)
+    val projection = ResumableProjection(projectionId)
+
+    (offset: Offset) =>
+      PersistenceQuery(as)
+        .readJournalFor[EventsByTagQuery](pluginId)
+        .eventsByTag(tag, offset)
+        .mapAsync(1) {
+          case EventEnvelope(off, persistenceId, sequenceNr, event) =>
+            log.debug("Processing event for persistence id '{}', seqNr '{}'", persistenceId, sequenceNr)
+            T.cast(event) match {
+              case Some(value) =>
+                index(value).map(_ => off)
+              case None =>
+                log.debug(s"Event not compatible with type '${T.describe}, skipping...'")
+                Future.successful(off)
+            }
+        }
+        .mapAsync(1)(offset => projection.storeLatestOffset(offset))
   }
 
-  private def buildStream(offset: Offset): RunnableGraph[(UniqueKillSwitch, Future[Done])] =
-    query
-      .eventsByTag(tag, offset)
-      .viaMat(KillSwitches.single)(Keep.right)
-      .mapAsync(1) {
-        case EventEnvelope(off, persistenceId, sequenceNr, event) =>
-          log.debug("Processing event for persistence id '{}', seqNr '{}'", persistenceId, sequenceNr)
-          T.cast(event) match {
-            case Some(value) =>
-              index(value).map(_ => off)
-            case None =>
-              log.debug(s"Event not compatible with type '${T.describe}, skipping...'")
-              Future.successful(off)
-          }
-      }
-      .mapAsync(1)(offset => projection.storeLatestOffset(offset))
-      .toMat(Sink.ignore)(Keep.both)
-
-  override def receive: Receive = {
-    case offset: Offset =>
-      log.info("Received initial offset, running the indexing function across the event stream")
-      val (killSwitch, doneFuture) = buildStream(offset).run()
-      doneFuture pipeTo self
-      context.become(running(killSwitch))
-    // $COVERAGE-OFF$
-    case Stop =>
-      log.info("Received stop signal while waiting for offset, stopping")
-      context.stop(self)
-    // $COVERAGE-ON$
-  }
-
-  private def running(killSwitch: UniqueKillSwitch): Receive = {
-    case Done =>
-      log.error("Stream finished unexpectedly, restarting")
-      killSwitch.shutdown()
-      initialize()
-      context.become(receive)
-    case Stop =>
-      log.info("Received stop signal, stopping stream")
-      killSwitch.shutdown()
-      context.become(stopping)
-  }
-
-  private def stopping: Receive = {
-    case Done =>
-      log.info("Stream finished, stopping")
-      context.stop(self)
-  }
-}
-
-object SequentialIndexer {
-
-  final case object Stop
-
+  /**
+    * Generic tag indexer that uses the specified resumable projection to iterate over the collection of events selected
+    * via the specified tag and apply the argument indexing function.  It starts as a singleton actor in a
+    * clustered deployment.  If the event type is not compatible with the events deserialized from the persistence store
+    * the events are skipped.
+    *
+    * @param init         an initialization function that is run before the indexer is (re)started
+    * @param index        the indexing function
+    * @param projectionId the id of the resumable projection to use
+    * @param pluginId     the persistence query plugin id
+    * @param tag          the tag to use while selecting the events from the store
+    * @param name         the name of this indexer
+    * @param as           an implicitly available actor system
+    * @param T            a Typeable instance for the event type T
+    * @tparam T the event type
+    */
   // $COVERAGE-OFF$
-  final def props[T: Typeable](init: () => Future[Unit],
-                               index: T => Future[Unit],
-                               projectionId: String,
-                               pluginId: String,
-                               tag: String)(implicit as: ActorSystem): Props =
-    ClusterSingletonManager.props(Props(new SequentialTagIndexer[T](init, index, projectionId, pluginId, tag)),
-                                  terminationMessage = Stop,
-                                  settings = ClusterSingletonManagerSettings(as))
+  final def start[T](init: () => Future[Unit],
+                     index: T => Future[Unit],
+                     projectionId: String,
+                     pluginId: String,
+                     tag: String,
+                     name: String)(implicit as: ActorSystem, T: Typeable[T]): ActorRef =
+    SingletonStreamCoordinator.start(initialize(init, pluginId), source(index, projectionId, pluginId, tag), name)
 
-  final def start[T: Typeable](init: () => Future[Unit],
-                               index: T => Future[Unit],
-                               projectionId: String,
-                               pluginId: String,
-                               tag: String,
-                               name: String)(implicit as: ActorSystem): ActorRef =
-    as.actorOf(props[T](init, index, projectionId, pluginId, tag), name)
-
-  final def start[T: Typeable](index: T => Future[Unit],
-                               projectionId: String,
-                               pluginId: String,
-                               tag: String,
-                               name: String)(implicit as: ActorSystem): ActorRef =
+  /**
+    * Generic tag indexer that uses the specified resumable projection to iterate over the collection of events selected
+    * via the specified tag and apply the argument indexing function.  It starts as a singleton actor in a
+    * clustered deployment.  If the event type is not compatible with the events deserialized from the persistence store
+    * the events are skipped.
+    *
+    * @param index        the indexing function
+    * @param projectionId the id of the resumable projection to use
+    * @param pluginId     the persistence query plugin id
+    * @param tag          the tag to use while selecting the events from the store
+    * @param name         the name of this indexer
+    * @param as           an implicitly available actor system
+    * @param T            a Typeable instance for the event type T
+    * @tparam T the event type
+    */
+  final def start[T](index: T => Future[Unit], projectionId: String, pluginId: String, tag: String, name: String)(
+      implicit as: ActorSystem,
+      T: Typeable[T]): ActorRef =
     start(() => Future.successful(()), index, projectionId, pluginId, tag, name)
-
   // $COVERAGE-ON$
 }

--- a/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/commons/service/stream/SingletonStreamCoordinator.scala
+++ b/modules/service/src/main/scala/ch/epfl/bluebrain/nexus/commons/service/stream/SingletonStreamCoordinator.scala
@@ -1,0 +1,123 @@
+package ch.epfl.bluebrain.nexus.commons.service.stream
+
+import akka.Done
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props, Status}
+import akka.cluster.singleton.{ClusterSingletonManager, ClusterSingletonManagerSettings}
+import akka.pattern.pipe
+import akka.stream.scaladsl.{Keep, RunnableGraph, Sink, Source}
+import akka.stream.{ActorMaterializer, KillSwitches, UniqueKillSwitch}
+import ch.epfl.bluebrain.nexus.commons.service.stream.SingletonStreamCoordinator._
+import shapeless.Typeable
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Actor implementation that builds and manages a stream ([[RunnableGraph]]).  It's purpose is to be run as a singleton
+  * actor in clustered deployments.
+  *
+  * @param init   an initialization function to be run when the actor starts, or when the stream is restarted
+  * @param source an initialization function that produces a stream from an initial start value
+  */
+class SingletonStreamCoordinator[A: Typeable, E](init: () => Future[A], source: A => Source[E, _])
+    extends Actor
+    with ActorLogging {
+
+  private val A                              = implicitly[Typeable[A]]
+  private implicit val as: ActorSystem       = context.system
+  private implicit val ec: ExecutionContext  = context.dispatcher
+  private implicit val mt: ActorMaterializer = ActorMaterializer()
+
+  private def initialize(): Unit = {
+    val _ = init().map(Start) pipeTo self
+  }
+
+  override def preStart(): Unit = {
+    super.preStart()
+    initialize()
+  }
+
+  private def buildStream(a: A): RunnableGraph[(UniqueKillSwitch, Future[Done])] = {
+    source(a)
+      .viaMat(KillSwitches.single)(Keep.right)
+      .toMat(Sink.ignore)(Keep.both)
+  }
+
+  override def receive: Receive = {
+    case Start(any) =>
+      A.cast(any) match {
+        case Some(a) =>
+          log.info("Received initial start value, running the indexing function across the element stream")
+          val (killSwitch, doneFuture) = buildStream(a).run()
+          doneFuture pipeTo self
+          context.become(running(killSwitch))
+        // $COVERAGE-OFF$
+        case _ =>
+          log.error("Received unknown initial start value '{}', expecting type '{}', stopping", any, A.describe)
+          context.stop(self)
+        // $COVERAGE-ON$
+      }
+    // $COVERAGE-OFF$
+    case Stop =>
+      log.info("Received stop signal while waiting for a start value, stopping")
+      context.stop(self)
+    // $COVERAGE-ON$
+  }
+
+  private def running(killSwitch: UniqueKillSwitch): Receive = {
+    case Done =>
+      log.error("Stream finished unexpectedly, restarting")
+      killSwitch.shutdown()
+      initialize()
+      context.become(receive)
+    // $COVERAGE-OFF$
+    case Status.Failure(th) =>
+      log.error("Stream finished unexpectedly with an error", th)
+      killSwitch.shutdown()
+      initialize()
+      context.become(receive)
+    // $COVERAGE-ON$
+    case Stop =>
+      log.info("Received stop signal, stopping stream")
+      killSwitch.shutdown()
+      context.become(stopping)
+  }
+
+  private def stopping: Receive = {
+    case Done =>
+      log.info("Stream finished, stopping")
+      context.stop(self)
+    // $COVERAGE-OFF$
+    case Status.Failure(th) =>
+      log.error("Stream finished with an error", th)
+      context.stop(self)
+    // $COVERAGE-ON$
+  }
+}
+
+object SingletonStreamCoordinator {
+  private[service] final case class Start(any: Any)
+  final case object Stop
+
+  /**
+    * Builds a [[Props]] for a [[SingletonStreamCoordinator]] with it cluster singleton configuration.
+    *
+    * @param init   an initialization function to be run when the actor starts, or when the stream is restarted
+    * @param source an initialization function that produces a stream from an initial start value
+    */
+  // $COVERAGE-OFF$
+  final def props[A: Typeable, E](init: () => Future[A], source: A => Source[E, _])(implicit as: ActorSystem): Props =
+    ClusterSingletonManager.props(Props(new SingletonStreamCoordinator(init, source)),
+                                  terminationMessage = Stop,
+                                  settings = ClusterSingletonManagerSettings(as))
+
+  /**
+    * Builds a cluster singleton actor of type [[SingletonStreamCoordinator]].
+    *
+    * @param init   an initialization function to be run when the actor starts, or when the stream is restarted
+    * @param source an initialization function that produces a stream from an initial start value
+    */
+  final def start[A: Typeable, E](init: () => Future[A], source: A => Source[E, _], name: String)(
+      implicit as: ActorSystem): ActorRef =
+    as.actorOf(props(init, source), name)
+  // $COVERAGE-ON$
+}


### PR DESCRIPTION
The stream coordination logic can be reused in a non indexing
scenario.