### PR TITLE
Port sparql client updates to master

### DIFF
--- a/modules/elastic-client/src/test/scala/ch/epfl/bluebrain/nexus/commons/es/client/ElasticClientSpec.scala
+++ b/modules/elastic-client/src/test/scala/ch/epfl/bluebrain/nexus/commons/es/client/ElasticClientSpec.scala
@@ -28,7 +28,7 @@ class ElasticClientSpec
     with CancelAfterFailure
     with Assertions {
 
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(6 seconds, 300 milliseconds)
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(10 seconds, 300 milliseconds)
 
   "An ElasticClient" should {
     implicit val ec: ExecutionContext          = system.dispatcher

--- a/modules/sparql-client/src/main/scala/ch/epfl/bluebrain/nexus/commons/sparql/client/SparqlFailure.scala
+++ b/modules/sparql-client/src/main/scala/ch/epfl/bluebrain/nexus/commons/sparql/client/SparqlFailure.scala
@@ -16,6 +16,7 @@ trait SparqlFailure extends Err {
   def body: String
 }
 
+// $COVERAGE-OFF$
 @SuppressWarnings(Array("IncorrectlyNamedExceptions"))
 object SparqlFailure {
 
@@ -73,3 +74,4 @@ object SparqlFailure {
       with SparqlFailure
 
 }
+// $COVERAGE-ON$


### PR DESCRIPTION
* Relaxed sparql client query validation for blazegraph specifics (#103)
* Updated the patch operation to select the correct triples (#104)