### PR TITLE
Added update mapping method

### DIFF
--- a/modules/elastic-client/src/test/resources/logback-test.xml
+++ b/modules/elastic-client/src/test/resources/logback-test.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/modules/elastic-client/src/test/resources/mapping_payload.json
+++ b/modules/elastic-client/src/test/resources/mapping_payload.json
@@ -1,0 +1,13 @@
+{
+  "properties": {
+    "key": {
+      "type": "keyword"
+    },
+    "/key2": {
+      "type": "keyword"
+    },
+    "age": {
+      "type": "integer"
+    }
+  }
+}


### PR DESCRIPTION
This allows us to create index and mapping in 2 steps, respecting the API and making ES validate the mapping (and not us checking for it as we did in KG): https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html#indices-put-mapping