### PR TITLE
Added url encoding for ids when needed

### DIFF
--- a/modules/elastic-client/src/test/scala/ch/epfl/bluebrain/nexus/commons/es/client/ElasticClientSpec.scala
+++ b/modules/elastic-client/src/test/scala/ch/epfl/bluebrain/nexus/commons/es/client/ElasticClientSpec.scala
@@ -367,7 +367,8 @@ class ElasticClientSpec
         }
 
         forAll(list) {
-          case (id, json) => cl.update(index, t, id, json deepMerge Json.obj("id" -> Json.fromString(id))).futureValue
+          case (id, _) =>
+            cl.update(index, t, id, Json.obj("doc" -> Json.obj("id" -> Json.fromString(id)))).futureValue
         }
 
         forAll(list) {


### PR DESCRIPTION
It is needed anytime the id is exposed on the ElasticSearch API path segment.