### PR TITLE
Updated ElasticSearch index API endpoint

### DIFF
--- a/modules/elastic-client/src/main/scala/ch/epfl/bluebrain/nexus/commons/es/client/ElasticSearchClient.scala
+++ b/modules/elastic-client/src/main/scala/ch/epfl/bluebrain/nexus/commons/es/client/ElasticSearchClient.scala
@@ -102,7 +102,7 @@ class ElasticSearchClient[F[_]](base: Uri, queryClient: ElasticSearchQueryClient
     */
   def create(index: String, id: String, payload: Json): F[Unit] =
     execute(
-      Put(base / sanitize(index, allowWildCard = false) / urlEncode(id), payload),
+      Put(base / sanitize(index, allowWildCard = false) / createPath / urlEncode(id), payload),
       Set(OK, Created),
       "create document"
     )
@@ -300,6 +300,7 @@ object ElasticSearchClient {
   }
 
   private[client] val updatePath              = "_update"
+  private[client] val createPath              = "_create"
   private[client] val updateByQueryPath       = "_update_by_query"
   private[client] val deleteByQueryPath       = "_delete_by_query"
   private[client] val includeFieldsQueryParam = "_source_includes"


### PR DESCRIPTION
Updated to `PUT /<index>/_create/<_id>` according to the [7.4 Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/docs-index_.html)