### PR TITLE
Addes support to override ElasticSearch document

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,13 +45,13 @@ val elasticSearchVersion  = "7.4.2"
 val jacksonVersion        = "2.10.1"
 val jacksonBindVersion    = "2.10.1"
 val journalVersion        = "3.0.19"
-val kryoVersion           = "1.0.0"
+val kryoVersion           = "1.1.0"
 val log4jVersion          = "2.12.1"
 val commonsIOVersion      = "1.3.2"
 val pureconfigVersion     = "0.12.1"
 val scalaTestVersion      = "3.0.8"
 val shapelessVersion      = "2.3.3"
-val topQuadrantVersion    = "1.3.0"
+val topQuadrantVersion    = "1.3.1"
 
 lazy val akkaActor                 = "com.typesafe.akka"                 %% "akka-actor"                   % akkaVersion
 lazy val akkaCluster               = "com.typesafe.akka"                 %% "akka-cluster"                 % akkaVersion

--- a/modules/elastic-client/src/test/scala/ch/epfl/bluebrain/nexus/commons/es/client/ElasticSearchClientSpec.scala
+++ b/modules/elastic-client/src/test/scala/ch/epfl/bluebrain/nexus/commons/es/client/ElasticSearchClientSpec.scala
@@ -117,6 +117,12 @@ class ElasticSearchClientSpec
         cl.bulk(ops).ioValue shouldEqual (())
       }
 
+      "override documents" in {
+        val (id, json) = list(0)
+        cl.create(indexSanitized, id, json, overrideIfExists = false).failed[Throwable]
+        cl.create(indexSanitized, id, json).ioValue
+      }
+
       "fetch documents" in {
         forAll(list) {
           case (id, json) =>


### PR DESCRIPTION
Used both endpoints:
`PUT /<index>/_doc/<_id>`
`PUT /<index>/_create/<_id>`


> You can index a new JSON document with the _doc or _create resource. Using _create guarantees that the document is only indexed if it does not already exist. To update an existing document, you must use the _doc resource.
